### PR TITLE
1.16.4 baubles

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,7 @@ dependencies {
     // at runtime, use the full JEI jar
     runtimeOnly fg.deobf("mezz.jei:jei-${modMinecraftVersion}:${jeiVersion}")
 
-    compile fg.deobf("com.github.lazyMods:Baubles:${baublesVersion}")
+    compile fg.deobf("com.github.lazyMods:Baubles:${baublesVersion}:api")
 
     runtimeOnly fg.deobf("top.theillusivec4.curios:curios-forge:${curiosVersion}")
     compileOnly fg.deobf("top.theillusivec4.curios:curios-forge:${curiosVersion}:api")

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ org.gradle.daemon=false
 #	 PATCH version when you make backwards-compatible bug fixes.
 # Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.
 # The initial alpha release is 0.1.0 and the initial public stable release should be 1.0.0
-modVersion = 1.0
+modVersion = 1.0.1
 
 # The modid of our mod
 modId = nomowanderer
@@ -28,7 +28,7 @@ modGroup = com.github.j-dill.nomowanderer
 modFileName = nomowanderer
 
 # The version of Minecraft we are modding for
-modMinecraftVersion = 1.16.3
+modMinecraftVersion = 1.16.4
 
 # The MCP Mappings the source code of the mod will be built against
 # MCP Mappings are in the format
@@ -40,13 +40,13 @@ modMinecraftVersion = 1.16.3
 # then refresh the gradle project in your IDE
 # and run the gredle task to generate the run configs for your IDE (genEclipseRuns or genIntellijRuns)
 modMcpMappingsChannel = snapshot
-modMcpMappingsVersion = 20200916-1.16.2
+modMcpMappingsVersion = 20201028-1.16.3
 
 # The Forge version the mod is being made for
-modForgeVersion = 34.1.0
+modForgeVersion = 35.1.10
 
-jeiVersion=7.5.0.41
+jeiVersion=7.6.0.58
 
-baublesVersion=1.8.2
+baublesVersion=1.8.5-1.16.4
 
-curiosVersion=1.16.3-4.0.2.0
+curiosVersion=1.16.4-4.0.3.0

--- a/src/main/java/nomowanderer/EntitySpawnHandler.java
+++ b/src/main/java/nomowanderer/EntitySpawnHandler.java
@@ -1,6 +1,6 @@
 package nomowanderer;
 
-import com.lazy.baubles.api.BaublesApi;
+import com.lazy.baubles.api.BaublesAPI;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.merchant.villager.WanderingTraderEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -63,7 +63,7 @@ public class EntitySpawnHandler {
         for(PlayerEntity player : entities) {
             if (player.inventory.hasAny(totemSet) ||
                     (curios && CuriosApi.getCuriosHelper().findEquippedCurio(RegistryEvents.noMoWandererTotemItem, player).isPresent()) ||
-                    (baubles && -1 != BaublesApi.isBaubleEquipped(player, RegistryEvents.noMoWandererTotemItem))
+                    (baubles && -1 != BaublesAPI.isBaubleEquipped(player, RegistryEvents.noMoWandererTotemItem))
             ) {
                 return true;
             }

--- a/src/main/java/nomowanderer/compat/ExternalMods.java
+++ b/src/main/java/nomowanderer/compat/ExternalMods.java
@@ -1,11 +1,12 @@
 package nomowanderer.compat;
 
+import com.lazy.baubles.api.BaublesAPI;
 import net.minecraftforge.fml.ModList;
 
 public enum ExternalMods {
 
     CURIOS("curios"),
-    BAUBLES("baubles");
+    BAUBLES(BaublesAPI.MOD_ID);
 
     private final boolean loaded;
 

--- a/src/main/java/nomowanderer/items/NoMoWandererTotemItem.java
+++ b/src/main/java/nomowanderer/items/NoMoWandererTotemItem.java
@@ -1,5 +1,7 @@
 package nomowanderer.items;
 
+import com.lazy.baubles.api.bauble.BaubleType;
+import com.lazy.baubles.api.bauble.IBauble;
 import com.lazy.baubles.api.cap.BaublesCapabilities;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.item.Item;
@@ -47,9 +49,9 @@ public class NoMoWandererTotemItem extends Item {
     @Nullable
     public ICapabilityProvider initCapabilities(ItemStack stack, @Nullable CompoundNBT nbt) {
         if (ExternalMods.BAUBLES.isLoaded()) {
-            com.lazy.baubles.api.IBauble iBauble = () -> com.lazy.baubles.api.BaubleType.TRINKET;
+            IBauble iBauble = (stack1) -> BaubleType.TRINKET;
             return new ICapabilityProvider() {
-                private final LazyOptional<com.lazy.baubles.api.IBauble> opt = LazyOptional.of(() -> iBauble);
+                private final LazyOptional<IBauble> opt = LazyOptional.of(() -> iBauble);
 
                 @Nonnull
                 @Override

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -4,7 +4,7 @@ loaderVersion="[34,)" #mandatory
 license="MIT License"
 [[mods]] #mandatory
 modId="nomowanderer" #mandatory
-version="1.16.3_1.0" #mandatory
+version="1.16.4_1.0.1" #mandatory
 displayName="NoMoWanderer" #mandatory
 credits="Big shoutout to computers, without you I would have no job." #optional
 authors="djmanly" #optional


### PR DESCRIPTION
## Port to 1.16.4 and fix on the Baubles implementation.

I'm the dev that is mantaining the Baubles mod, and I received a issue related to your mod. This issue makes the game crash when trying to apply some sort of Resource Pack.
Turns out, the person is using your 1.16.3 mod in a 1.16.4 modpack with Baubles to 1.16.4 that cause the game to crash.
With this happening I decided to port it myself and create a PR with the changes.

**Changes made:**
- Bumped version of the dependencies used in the mod.
- Fix the Baubles dependencie (you need to specify the artifact ":api" at the end)
- Fix the Bauble capability.

**Note:** The mod version was bumped to 1.0.1, since this only a minor patch, but you can change it.